### PR TITLE
Flush logs on destruction (#1):

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,7 @@ build:debug --config=warning:all
 
 build:release --compilation_mode=opt
 build:release --config=assert:none
-build:release --config=log:critical
+build:release --config=log:error
 build:release --config=warning:all
 
 # Optional Flags                                                   [ Optional ]

--- a/andromeda/core/system/log/log.hpp
+++ b/andromeda/core/system/log/log.hpp
@@ -22,6 +22,10 @@ namespace Andromeda::System {
         Log() = delete;
         static void initialize(Log::Configuration configuration);
         static void shutdown() {
+            s_Core->flush();
+            s_Instance->flush();
+            s_Core.reset();
+            s_Instance.reset();
             spdlog::shutdown();
         }
         static std::shared_ptr<spdlog::logger> & core() {


### PR DESCRIPTION
    - Async logs require waiting on threads.
    - Reset wrapper pointers