### PR TITLE
Remove `const` restriction on callbacks (#1):

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -114,6 +114,9 @@ build:sanitizer --strip=never
 build:sanitizer --force_ignore_dash_static
 build:sanitizer --test_timeout=120,600,1800,-1
 build:sanitizer --cxxopt=-fno-omit-frame-pointer
+# TODO__ANDROMEDA: https://libcxx.llvm.org/Status/Cxx20.html __ANDROMEDA__FUTURE__
+# build:sanitizer --cxxopt=-stdlib=libc++ 
+
 
 ###############################################################################
 # .bazelrc workspace & user overrides                                 [ Bazel ]

--- a/andromeda/core/system/graphics/display/manager.hpp
+++ b/andromeda/core/system/graphics/display/manager.hpp
@@ -12,10 +12,10 @@ namespace Andromeda::System::Graphics::Display {
       public:
         struct Callbacks {
             struct Display {
-                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Update, const Manager *> update;
-                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Initialize, const Manager *> initialize;
-                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Interrupt, const Manager *> interrupt;
-                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Terminate, const Manager *> terminate;
+                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Update, Manager *> update;
+                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Initialize, Manager *> initialize;
+                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Interrupt, Manager *> interrupt;
+                Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Instance::Display::Terminate, Manager *> terminate;
             };
             std::shared_ptr<Manager::Callbacks::Display> display = std::make_shared<Manager::Callbacks::Display>();
             std::shared_ptr<Window::Callbacks> window = std::make_shared<Window::Callbacks>();

--- a/andromeda/core/system/graphics/display/monitor.hpp
+++ b/andromeda/core/system/graphics/display/monitor.hpp
@@ -21,8 +21,8 @@ namespace Andromeda::System::Graphics::Display {
             int width, height;
         };
         struct Callbacks {
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Monitor::Connect, const Monitor *> connect;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Monitor::Disconnect, const Monitor *> disconnect;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Monitor::Connect, Monitor *> connect;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Monitor::Disconnect, Monitor *> disconnect;
         };
         struct Configuration {
             std::string title;

--- a/andromeda/core/system/graphics/display/window.hpp
+++ b/andromeda/core/system/graphics/display/window.hpp
@@ -25,16 +25,16 @@ namespace Andromeda::System::Graphics::Display {
             Fullscreen = Andromeda::Numerics::Bit(5),
         };
         struct Callbacks {
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Move, const Window *> move;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Resize, const Window *> resize;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Close, const Window *> close;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Refresh, const Window *> refresh;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Focus, const Window *> focus;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Defocus, const Window *> defocus;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Maximize, const Window *> maximize;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Minimize, const Window *> minimize;
-            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Restore, const Window *> restore;
-            Andromeda::System::Input::Manager::Callbacks<const Window *> input;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Move, Window *> move;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Resize, Window *> resize;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Close, Window *> close;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Refresh, Window *> refresh;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Focus, Window *> focus;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Defocus, Window *> defocus;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Maximize, Window *> maximize;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Minimize, Window *> minimize;
+            Andromeda::System::Event::Manager::Serial<Andromeda::System::Event::Window::Restore, Window *> restore;
+            Andromeda::System::Input::Manager::Callbacks<Window *> input;
         };
         struct Configuration {
             std::string title;


### PR DESCRIPTION
    - Some callbacks will inevitably call mutator methods on the window
       so encouraging callbacks to const correct during implementation
       is preferrable.