### PR TITLE
Bitmask API Change & Bugfix (#1):

### DIFF
--- a/andromeda/core/system/platform/linux/graphics/display/window.cpp
+++ b/andromeda/core/system/platform/linux/graphics/display/window.cpp
@@ -14,13 +14,14 @@ namespace Andromeda::System::Linux::Graphics::Display {
     }
 
     void Window::initialize() {
-        glfwWindowHint(GLFW_DECORATED, m_Configuration.options >= Options::Decorated);
-        glfwWindowHint(GLFW_RESIZABLE, m_Configuration.options >= Options::Resizable);
-        glfwWindowHint(GLFW_VISIBLE, m_Configuration.options >= Options::Visible);
-        glfwWindowHint(GLFW_FLOATING, m_Configuration.options >= Options::Floating);
+        ANDROMEDA_CORE_INFO("Window Confuration Options {5}:\n\t\tDecorated: {0}\n\t\tResizable: {1}\n\t\tVisible: {2}\n\t\tFloating: {3}\n\t\tFullscreen: {4}.", (m_Configuration.options >> Options::Decorated), (m_Configuration.options >> Options::Resizable),  (m_Configuration.options >> Options::Visible), (m_Configuration.options >> Options::Floating), (m_Configuration.options >> Options::Fullscreen), m_Configuration.options);
+        glfwWindowHint(GLFW_DECORATED, m_Configuration.options >> Options::Decorated);
+        glfwWindowHint(GLFW_RESIZABLE, m_Configuration.options >> Options::Resizable);
+        glfwWindowHint(GLFW_VISIBLE, m_Configuration.options >> Options::Visible);
+        glfwWindowHint(GLFW_FLOATING, m_Configuration.options >> Options::Floating);
 
-        if (m_Configuration.options >= Window::Options::Subscreen) subscreen();
-        if (m_Configuration.options >= Window::Options::Fullscreen) fullscreen();
+        if (m_Configuration.options >> Window::Options::Subscreen) subscreen();
+        if (m_Configuration.options >> Window::Options::Fullscreen) fullscreen();
 
         ANDROMEDA_CORE_ASSERT(m_Native != nullptr, "Window not created, native pointer is nullified.");
 

--- a/andromeda/core/system/structure/bitmask.hpp
+++ b/andromeda/core/system/structure/bitmask.hpp
@@ -16,6 +16,16 @@ namespace Andromeda::Structure::Concept {
 } /* Andromeda::Structure::Concept */
 
 template <Andromeda::Structure::Concept::Bitmask Element>
+constexpr bool operator >> (Element lhs, Element rhs) {
+    using T = std::underlying_type_t<Element>;
+    return (static_cast<Element>(static_cast<T>(lhs) & static_cast<T>(rhs)) == rhs);
+}
+template <Andromeda::Structure::Concept::Bitmask Element>
+constexpr bool operator << (Element lhs, Element rhs) {
+    using T = std::underlying_type_t<Element>;
+    return (static_cast<Element>(static_cast<T>(rhs) & static_cast<T>(lhs)) == lhs);
+}
+template <Andromeda::Structure::Concept::Bitmask Element>
 constexpr Element operator & (Element lhs, Element rhs) {
     using T = std::underlying_type_t<Element>;
     return static_cast<Element>(static_cast<T>(lhs) & static_cast<T>(rhs));
@@ -47,32 +57,11 @@ constexpr Element & operator ^= (Element & lhs, Element rhs) {
 }
 template <Andromeda::Structure::Concept::Bitmask Element>
 constexpr Element operator - (Element lhs, Element rhs) {
-    return lhs ^ (lhs & rhs);
+    using T = std::underlying_type_t<Element>;
+    return lhs ^ static_cast<Element>(static_cast<T>(lhs) & static_cast<T>(rhs));
 }
 template <Andromeda::Structure::Concept::Bitmask Element>
 constexpr Element & operator -= (Element & lhs, Element rhs) {
     lhs = lhs - rhs;
     return lhs;
-}
-template <Andromeda::Structure::Concept::Bitmask Element>
-constexpr bool operator > (Element lhs, Element rhs) {
-    using T = std::underlying_type_t<Element>;
-    return static_cast<T>(lhs & rhs) > 0;
-}
-template <Andromeda::Structure::Concept::Bitmask Element>
-constexpr bool operator >= (Element lhs, Element rhs) {
-    return (lhs > rhs) || (lhs == rhs);
-}
-template <Andromeda::Structure::Concept::Bitmask Element>
-constexpr bool operator == (Element lhs, Element rhs) {
-    return lhs == rhs;
-}
-template <Andromeda::Structure::Concept::Bitmask Element>
-constexpr bool operator <= (Element lhs, Element rhs) {
-    return (lhs < rhs) || (lhs == rhs);
-}
-template <Andromeda::Structure::Concept::Bitmask Element>
-constexpr bool operator < (Element lhs, Element rhs) {
-    using T = std::underlying_type_t<Element>;
-    return static_cast<T>(lhs - rhs) == 0;
 }

--- a/andromeda/test/core/core.cc
+++ b/andromeda/test/core/core.cc
@@ -7,6 +7,8 @@ TEST(Core, Constants) {
     EXPECT_EQ(2, Andromeda::Numerics::Bit(1));
     EXPECT_EQ(4, Andromeda::Numerics::Bit(2));
     EXPECT_EQ(8, Andromeda::Numerics::Bit(3));
+    EXPECT_EQ(16, Andromeda::Numerics::Bit(4));
+    EXPECT_EQ(32, Andromeda::Numerics::Bit(5));
     EXPECT_EQ(64, Andromeda::Numerics::Bit(6));
     EXPECT_EQ("Andromeda", Andromeda::Titles::engine);
 }

--- a/andromeda/test/core/system/structure/bitmask.cc
+++ b/andromeda/test/core/system/structure/bitmask.cc
@@ -6,24 +6,29 @@
 
 enum class Test_Enum {
     None = 0,
-    Test2 = Andromeda::Numerics::Bit(0),
-    Test4 = Andromeda::Numerics::Bit(1),
-    Test8 = Andromeda::Numerics::Bit(2),
-    Test16 = Andromeda::Numerics::Bit(3),
-    Test32 = Andromeda::Numerics::Bit(4),
+    Test1 = Andromeda::Numerics::Bit(0),
+    Test2 = Andromeda::Numerics::Bit(1),
+    Test4 = Andromeda::Numerics::Bit(2),
+    Test8 = Andromeda::Numerics::Bit(3),
+    Test16 = Andromeda::Numerics::Bit(4),
+    Test32 = Andromeda::Numerics::Bit(5),
+    Test64 = Andromeda::Numerics::Bit(6),
 };
 Andromeda::Structure::Concept::Tag bitmask(Test_Enum);
 
 TEST(Bitmask, Common) {
     auto test = Test_Enum::Test2 + Test_Enum::Test4 + Test_Enum::Test32;
     auto test2 = Test_Enum::Test16 + Test_Enum::Test8 + Test_Enum::Test32;
-    EXPECT_TRUE((test & test2) == Test_Enum::Test32);
+    EXPECT_TRUE(static_cast<int>(test2) == 16+8+32);
+    EXPECT_FALSE((Test_Enum::Test2+Test_Enum::Test16) == Test_Enum::Test16);
+    EXPECT_FALSE((test >> test2));
+    EXPECT_FALSE(Test_Enum::Test1 == Test_Enum::Test2 || Test_Enum::Test2 + Test_Enum::Test32 + Test_Enum::Test16 == Test_Enum::Test16);
 }
 
 TEST(Bitmask, Add) {
     auto test = Test_Enum::Test2 + Test_Enum::Test4;
-    EXPECT_TRUE(test > Test_Enum::Test2);
-    EXPECT_TRUE(test > Test_Enum::Test4);
+    EXPECT_TRUE((test >> Test_Enum::Test2));
+    EXPECT_TRUE((test >> Test_Enum::Test4));
     EXPECT_TRUE(test == Test_Enum::Test2 + Test_Enum::Test4);
 }
 
@@ -31,18 +36,19 @@ TEST(Bitmask, Remove) {
     auto test = Test_Enum::Test2 + Test_Enum::Test4;
     test -= Test_Enum::Test4;
     EXPECT_TRUE(test == Test_Enum::Test2);
-    EXPECT_TRUE(test <= Test_Enum::Test2);
-    EXPECT_FALSE(test > Test_Enum::Test4);
+    EXPECT_FALSE((test >> Test_Enum::Test4));
+}
+
+TEST(Bitmask, And) {
+    EXPECT_TRUE((Test_Enum::Test2 + Test_Enum::Test16) >> Test_Enum::Test16);
+    EXPECT_FALSE((Test_Enum::Test2 + Test_Enum::Test16) >> Test_Enum::Test4);
 }
 
 TEST(Bitmask, Sets) {
     auto test = Test_Enum::Test16 + Test_Enum::Test8;
     auto test2 = Test_Enum::Test16 + Test_Enum::Test4;
     auto test3 = Test_Enum::Test2 + Test_Enum::Test8 + Test_Enum::Test16 + Test_Enum::Test32;
-    EXPECT_TRUE(test3 > test);
-    EXPECT_TRUE(test3 >= test);
-    EXPECT_TRUE(test < test3);
-    EXPECT_TRUE(test <= test3);
-    EXPECT_TRUE((test2 & test) == Test_Enum::Test16);
-    EXPECT_TRUE((test2 ^ test) == Test_Enum::Test8 + Test_Enum::Test4);
+    EXPECT_TRUE(test3 >> test);
+    EXPECT_FALSE((test2 >> test3));
+    EXPECT_TRUE((test2 >> Test_Enum::None));
 }


### PR DESCRIPTION
    - Enum classes do not allow <=> operator overloads.